### PR TITLE
expose SemaphorePermits and OwnedSemaphorePermits

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -452,7 +452,7 @@ cfg_sync! {
     pub(crate) mod batch_semaphore;
     pub(crate) mod semaphore_ll;
     mod semaphore;
-    pub use semaphore::{Semaphore, SemaphorePermit, OwnedSemaphorePermit};
+    pub use semaphore::{Semaphore, SemaphorePermit, OwnedSemaphorePermit, SemaphorePermits, OwnedSemaphorePermits};
 
     mod rwlock;
     pub use rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};


### PR DESCRIPTION
# The problem
Because the `tokio::sync::semaphore` is private, users can't reference `tokio::sync::semaphore::SemaphorePermits` from their functions.  

# The solution
* Expose `tokio::sync::semaphore::SemaphorePermits` and `tokio::sync::semaphore::OwnedSemaphorePermits` to scope `tokio::sync`.