### PR TITLE
Semaphoren

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -452,7 +452,7 @@ cfg_sync! {
     pub(crate) mod batch_semaphore;
     pub(crate) mod semaphore_ll;
     mod semaphore;
-    pub use semaphore::{Semaphore, SemaphorePermit, OwnedSemaphorePermit};
+    pub use semaphore::{Semaphore, SemaphorePermit, OwnedSemaphorePermit, SemaphorePermits, OwnedSemaphorePermits};
 
     mod rwlock;
     pub use rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -115,7 +115,7 @@ impl<'a, T> ReleasingPermit<'a, T> {
         lock: &'a RwLock<T>,
         num_permits: u16,
     ) -> Result<ReleasingPermit<'a, T>, AcquireError> {
-        lock.s.acquire(num_permits).await?;
+        lock.s.acquire(num_permits.into()).await?;
         Ok(Self { num_permits, lock })
     }
 }

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -40,6 +40,30 @@ pub struct OwnedSemaphorePermit {
     sem: Option<Arc<Semaphore>>,
 }
 
+/// A number of permits from the semaphore.
+///
+/// This type is created by the [`acquire_n`] method.
+///
+/// [`acquire_n`]: crate::sync::Semaphore::acquire_n()
+#[must_use]
+#[derive(Debug)]
+pub struct SemaphorePermits<'a> {
+    sem: &'a Semaphore,
+    permits: u32,
+}
+
+/// An owned variant for a number of permit from the semaphore.
+///
+/// This type is created by the [`acquire_n_owned`] method.
+///
+/// [`acquire_n_owned`]: crate::sync::Semaphore::acquire_n_owned()
+#[must_use]
+#[derive(Debug)]
+pub struct OwnedSemaphorePermits {
+    sem: Arc<Semaphore>,
+    permits: u32,
+}
+
 /// Error returned from the [`Semaphore::try_acquire`] function.
 ///
 /// A `try_acquire` operation can only fail if the semaphore has no available
@@ -90,11 +114,20 @@ impl Semaphore {
         self.ll_sem.release(n);
     }
 
-    /// Acquires permit from the semaphore.
+    /// Acquires one permit from the semaphore.
     pub async fn acquire(&self) -> SemaphorePermit<'_> {
         self.ll_sem.acquire(1).await.unwrap();
         SemaphorePermit {
             sem: &self,
+        }
+    }
+
+    /// Acquires a number of permits from the semaphore.
+    pub async fn acquire_n(&self, num_permits: u32) -> SemaphorePermits<'_> {
+        self.ll_sem.acquire(num_permits).await.unwrap();
+        SemaphorePermits {
+            sem: &self,
+            permits: num_permits,
         }
     }
 
@@ -103,6 +136,17 @@ impl Semaphore {
         match self.ll_sem.try_acquire(1) {
             Ok(_) => Ok(SemaphorePermit {
                 sem: self,
+            }),
+            Err(_) => Err(TryAcquireError(())),
+        }
+    }
+
+    /// Tries to acquire a number of permits from the semaphore.
+    pub fn try_acquire_n(&self, num_permits: u32) -> Result<SemaphorePermits<'_>, TryAcquireError> {
+        match self.ll_sem.try_acquire(num_permits) {
+            Ok(_) => Ok(SemaphorePermits {
+                sem: self,
+                permits: num_permits,
             }),
             Err(_) => Err(TryAcquireError(())),
         }
@@ -120,6 +164,19 @@ impl Semaphore {
         }
     }
 
+    /// Acquires a number of permits from the semaphore.
+    ///
+    /// The semaphore must be wrapped in an [`Arc`] to call this method.
+    ///
+    /// [`Arc`]: std::sync::Arc
+    pub async fn acquire_n_owned(self: Arc<Self>, num_permits: u32) -> OwnedSemaphorePermits {
+        self.ll_sem.acquire(num_permits).await.unwrap();
+        OwnedSemaphorePermits {
+            sem: self.clone(),
+            permits: num_permits,
+        }
+    }
+
     /// Tries to acquire a permit from the semaphore.
     ///
     /// The semaphore must be wrapped in an [`Arc`] to call this method.
@@ -129,6 +186,21 @@ impl Semaphore {
         match self.ll_sem.try_acquire(1) {
             Ok(_) => Ok(OwnedSemaphorePermit {
                 sem: Some(self.clone()),
+            }),
+            Err(_) => Err(TryAcquireError(())),
+        }
+    }
+
+    /// Tries to acquire a number of permits from the semaphore.
+    ///
+    /// The semaphore must be wrapped in an [`Arc`] to call this method.
+    ///
+    /// [`Arc`]: std::sync::Arc
+    pub fn try_acquire_n_owned(self: Arc<Self>, num_permits: u32) -> Result<OwnedSemaphorePermits, TryAcquireError> {
+        match self.ll_sem.try_acquire(num_permits) {
+            Ok(_) => Ok(OwnedSemaphorePermits {
+                sem: self.clone(),
+                permits: num_permits,
             }),
             Err(_) => Err(TryAcquireError(())),
         }
@@ -146,16 +218,6 @@ impl<'a> SemaphorePermit<'a> {
     }
 }
 
-impl OwnedSemaphorePermit {
-    /// Forgets the permit **without** releasing it back to the semaphore.
-    /// This can be used to reduce the amount of permits available from a
-    /// semaphore.
-    pub fn forget(mut self) {
-        // the destructor won't be able to release the permits
-        self.sem = None;
-    }
-}
-
 impl<'a> Drop for SemaphorePermit<'_> {
     fn drop(&mut self) {
         self.sem.add_permits(1);
@@ -167,5 +229,45 @@ impl Drop for OwnedSemaphorePermit {
         if let Some(ref mut sem) = self.sem {
             sem.add_permits(1);
         }
+    }
+}
+
+impl OwnedSemaphorePermit {
+    /// Forgets the permit **without** releasing it back to the semaphore.
+    /// This can be used to reduce the amount of permits available from a
+    /// semaphore.
+    pub fn forget(mut self) {
+        // the destructor won't be able to release the permits
+        self.sem = None;
+    }
+}
+
+impl<'a> SemaphorePermits<'a> {
+    /// Forgets the permits **without** releasing them back to the semaphore.
+    /// This can be used to reduce the amount of permits available from a
+    /// semaphore.
+    pub fn forget(mut self) {
+        self.permits = 0;
+    }
+}
+
+impl<'a> Drop for SemaphorePermits<'_> {
+    fn drop(&mut self) {
+        self.sem.add_permits(self.permits as usize);
+    }
+}
+
+impl OwnedSemaphorePermits {
+    /// Forgets the permits **without** releasing them back to the semaphore.
+    /// This can be used to reduce the amount of permits available from a
+    /// semaphore.
+    pub fn forget(mut self) {
+        self.permits = 0;
+    }
+}
+
+impl Drop for OwnedSemaphorePermits {
+    fn drop(&mut self) {
+        self.sem.add_permits(self.permits as usize);
     }
 }

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -254,6 +254,27 @@ impl<'a> SemaphorePermits<'a> {
     pub fn num_permits(&self) -> u32 {
         self.permits
     }
+
+    /// Release a number of permits back to the semaphore.
+    ///
+    /// The maximum number of permits is `self.num_permits()`, and this function will panic if the limit is exceeded.
+    pub fn release_n(&mut self, num_permits: u32) {
+        if self.permits < num_permits {
+            panic!("No enough permits available");
+        }
+        self.permits -= num_permits;
+        self.sem.add_permits(num_permits as usize);
+    }
+
+    /// Forgets a number of permits **without** releasing them back to the semaphore.
+    ///
+    /// The maximum number of permits is `self.num_permits()`, and this function will panic if the limit is exceeded.
+    pub fn forget_n(&mut self, num_permits: u32) {
+        if self.permits < num_permits {
+            panic!("No enough permits available");
+        }
+        self.permits -= num_permits;
+    }
 }
 
 impl<'a> Drop for SemaphorePermits<'_> {
@@ -273,6 +294,27 @@ impl OwnedSemaphorePermits {
     /// Number of permits acquired in this instance
     pub fn num_permits(&self) -> u32 {
         self.permits
+    }
+
+    /// Release a number of permits back to the semaphore.
+    ///
+    /// The maximum number of permits is `self.num_permits()`, and this function will panic if the limit is exceeded.
+    pub fn release_n(&mut self, num_permits: u32) {
+        if self.permits < num_permits {
+            panic!("No enough permits available");
+        }
+        self.permits -= num_permits;
+        self.sem.add_permits(num_permits as usize);
+    }
+
+    /// Forgets a number of permits **without** releasing them back to the semaphore.
+    ///
+    /// The maximum number of permits is `self.num_permits()`, and this function will panic if the limit is exceeded.
+    pub fn forget_n(&mut self, num_permits: u32) {
+        if self.permits < num_permits {
+            panic!("No enough permits available");
+        }
+        self.permits -= num_permits;
     }
 }
 

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -249,6 +249,11 @@ impl<'a> SemaphorePermits<'a> {
     pub fn forget(mut self) {
         self.permits = 0;
     }
+
+    /// Number of permits acquired in this instance
+    pub fn num_permits(&self) -> u32 {
+        self.permits
+    }
 }
 
 impl<'a> Drop for SemaphorePermits<'_> {
@@ -263,6 +268,11 @@ impl OwnedSemaphorePermits {
     /// semaphore.
     pub fn forget(mut self) {
         self.permits = 0;
+    }
+
+    /// Number of permits acquired in this instance
+    pub fn num_permits(&self) -> u32 {
+        self.permits
     }
 }
 

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -214,6 +214,8 @@ async_assert_fn!(tokio::sync::RwLock<Cell<u8>>::write(_): !Send & !Sync);
 async_assert_fn!(tokio::sync::RwLock<Rc<u8>>::read(_): !Send & !Sync);
 async_assert_fn!(tokio::sync::RwLock<Rc<u8>>::write(_): !Send & !Sync);
 async_assert_fn!(tokio::sync::Semaphore::acquire(_): Send & Sync);
+async_assert_fn!(tokio::sync::Semaphore::acquire_n(_, _): Send & Sync);
+async_assert_fn!(tokio::sync::Semaphore::acquire_n_owned(_, _): Send & Sync);
 
 async_assert_fn!(tokio::sync::broadcast::Receiver<u8>::recv(_): Send & Sync);
 async_assert_fn!(tokio::sync::broadcast::Receiver<Cell<u8>>::recv(_): Send & Sync);

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -58,6 +58,53 @@ fn forget() {
     assert!(sem.try_acquire().is_err());
 }
 
+#[test]
+fn release_n() {
+    let sem = Arc::new(Semaphore::new(3));
+    {
+        let p1 = sem.try_acquire_n(3);
+        assert!(p1.is_ok());
+        let mut p1 = p1.unwrap();
+        p1.release_n(2);
+        let p2 = sem.try_acquire_n(2);
+        assert!(p2.is_ok());
+    }
+    let p3 = sem.try_acquire_n(3);
+    assert!(p3.is_ok());
+}
+
+#[test]
+#[should_panic(expected = "No enough permits available")]
+fn release_n_panic() {
+    let sem = Arc::new(Semaphore::new(3));
+    let p1 = sem.try_acquire_n(3);
+    assert!(p1.is_ok());
+    let mut p1 = p1.unwrap();
+    p1.release_n(4);
+}
+
+#[test]
+fn forget_n() {
+    let sem = Arc::new(Semaphore::new(3));
+    {
+        let mut p = sem.try_acquire_n(3).unwrap();
+        assert_eq!(sem.available_permits(), 0);
+        p.forget_n(3);
+        assert_eq!(sem.available_permits(), 0);
+    }
+    assert_eq!(sem.available_permits(), 0);
+    assert!(sem.try_acquire().is_err());
+}
+
+#[test]
+#[should_panic(expected = "No enough permits available")]
+fn forget_n_panic() {
+    let sem = Arc::new(Semaphore::new(3));
+    let mut p = sem.try_acquire_n(3).unwrap();
+    assert_eq!(sem.available_permits(), 0);
+    p.forget_n(4);
+}
+
 #[tokio::test]
 async fn stresstest() {
     let sem = Arc::new(Semaphore::new(5));

--- a/tokio/tests/sync_semaphore_owned.rs
+++ b/tokio/tests/sync_semaphore_owned.rs
@@ -47,6 +47,18 @@ async fn acquire() {
 }
 
 #[tokio::test]
+async fn acquire_n() {
+    let sem = Arc::new(Semaphore::new(5));
+    let p1 = sem.clone().try_acquire_n_owned(3).unwrap();
+    let sem_clone = sem.clone();
+    let j = tokio::spawn(async move {
+        let _p2 = sem_clone.acquire_n_owned(2).await;
+    });
+    drop(p1);
+    j.await.unwrap();
+}
+
+#[tokio::test]
 async fn add_permits() {
     let sem = Arc::new(Semaphore::new(0));
     let sem_clone = sem.clone();

--- a/tokio/tests/sync_semaphore_owned.rs
+++ b/tokio/tests/sync_semaphore_owned.rs
@@ -16,6 +16,24 @@ fn try_acquire() {
     assert!(p3.is_ok());
 }
 
+#[test]
+fn try_acquire_n() {
+    let sem = Arc::new(Semaphore::new(3));
+    {
+        let p1 = sem.clone().try_acquire_n_owned(4);
+        assert!(p1.is_err());
+        let p2 = sem.clone().try_acquire_n_owned(2);
+        match p2.as_ref() {
+            Ok(p2) => assert_eq!(2, p2.num_permits()),
+            Err(_) => panic!(),
+        };
+        let p3 = sem.clone().try_acquire_n_owned(2);
+        assert!(p3.is_err());
+    }
+    let p4 = sem.try_acquire_owned();
+    assert!(p4.is_ok());
+}
+
 #[tokio::test]
 async fn acquire() {
     let sem = Arc::new(Semaphore::new(1));


### PR DESCRIPTION
1. Implemented `release_n` and `forget_n` function for `SemaphorePermits` and `OwnedSemaphorePermits`.
2. Add more tests for `acquire_n`, `try_acquire_n`, `acquire_n_owned`, `try_acquire_n_owned`

See https://github.com/tokio-rs/tokio/issues/1550#issuecomment-653094445